### PR TITLE
Add unimplemented methods, doc, fix POST data in some calls

### DIFF
--- a/jupyterhub_client/base.py
+++ b/jupyterhub_client/base.py
@@ -31,20 +31,33 @@ class BaseJupyterHubClient(object):
     
     def fetch(self, url, method, body):
         raise NotImplementedError("Must be implemented in a subclass")
+
+    def info(self):
+        """Get detailed info about JupyterHub"""
+        return self._api_request('/info', method='GET')
     
     def list_users(self):
         """List users"""
-        return self._api_request('/users')
+        return self._api_request('/users', method='GET')
     
-    def create_users(self, *users):
-        """Create one or more users."""
-        return self._api_request('/users', method='POST', data=users)
+    def create_users(self, names, admin=False):
+        """Create one or more users.
+        
+        Args
+        ----
+            names : list of str
+            admin : bool
+        """
+        data = {"usernames": names, "admin": admin}
+        return self._api_request('/users', method='POST', data=data)
 
     def delete_user(self, name):
+        """Delete a user"""
         self._api_request('/users/{name}'.format(name=name), method='DELETE')
 
     def get_user(self, name):
-        self._api_request('/users/{name}'.format(name=name), method='GET')
+        """Get a user by name"""
+        return self._api_request('/users/{name}'.format(name=name), method='GET')
 
     def modify_user(self, username, admin=None, name=None):
         """Update an existing user"""
@@ -60,41 +73,61 @@ class BaseJupyterHubClient(object):
 
     def create_user(self, name, admin=False):
         """Create a single user"""
-        return self.create_users({'name': name, 'admin': admin})
+        return self.create_users([name], admin)
 
     def stop_server(self, name):
         """Stop a user's server"""
         return self._api_request('/users/{name}/server'.format(name=name), method='DELETE')
 
     def start_server(self, name):
-        """Start a user's server"""
+        """Start a user's single-user notebook server"""
         return self._api_request('/users/{name}/server'.format(name=name), method='POST')
+
+    def grant_admin_access_server(self, name):
+        """Grant admin access to this user's otebook server"""
+        return self._api_request('/users/{name}/admin-access'.format(name=name), method='POST')
 
     def list_groups(self):
         """List groups"""
-        return self._api_request('/groups')
+        return self._api_request('/groups', method='GET')
 
     def create_group(self, name):
-        """Create one or more groups."""
+        """Create a group"""
         return self._api_request('/groups/{name}'.format(name=name), method='POST')
 
     def delete_group(self, name):
+        """Delete a group"""
         return self._api_request('/groups/{name}'.format(name=name), method='DELETE')
 
     def get_group(self, name):
+        """Get a group by name"""
         return self._api_request('/groups/{name}'.format(name=name), method='GET')
 
     def add_group_users(self, group, users):
         """Add users to a group by name"""
-        return self._api_request('/groups/{name}/users'.format(name=group), method='POST', data=users)
+        if isinstance(users, str):
+            users = [users]
+        data = {"users": users}
+        return self._api_request('/groups/{name}/users'.format(name=group), method='POST', data=data)
 
     def drop_group_users(self, group, users):
         """Remove users from a group by name"""
-        return self._api_request('/groups/{name}/users'.format(name=group), method='DELETE', data=users)
+        if isinstance(users, str):
+            users = [users]
+        data = {"users": users}
+        return self._api_request('/groups/{name}/users'.format(name=group), method='DELETE', data=data)
+
+    def list_services(self):
+        """List services"""
+        return self._api_request('/services', method='GET')
+
+    def get_service(self, name):
+        """Get a service by name"""
+        return self._api_request('/services/{name}'.format(name=name), method='GET')
 
     def get_proxy_table(self):
         """Get the proxy's current routing table"""
-        return self._api_request('/proxy')
+        return self._api_request('/proxy', method='GET')
     
     def new_proxy(self, ip=None, port=None, protocol=None, auth_token=None):
         """Point the Hub to a new proxy"""
@@ -123,7 +156,17 @@ class BaseJupyterHubClient(object):
         return self._api_request('/authorizations/cookie/{name}/{value}'.format(name=name, value=value))
 
     def shutdown(self, proxy=None, servers=None):
-        """Shutdown the Hub"""
+        """Shutdown the Hub
+        
+        Args
+        ----
+            proxy : bool
+                Whether the proxy should be shutdown as well
+                (default from Hub config)
+            servers : bool
+                Whether the users' notebook servers should be shutdown as well
+                (default from Hub config)
+        """
         data = {}
         if proxy is not None:
             data['proxy'] = proxy


### PR DESCRIPTION
Add a couple unimplemented methods:
- list services
- get a service
- info
- grant admin access to user server

Add docstrings everywhere, matching the Hub REST API documentation, and in some cases document types of arguments.

Try to make `create_user` and `create_users` work nicely together, which were causing errors in my application. Previously, `create_users` takes a list of some `users` object. Seems like this object, from the `create_user` signature, has keys `name` and `value`, and these objects were appended together in a new list. However, current REST API signature for create multiple users takes data:
```
{
  "usernames": [
    "string"
  ],
  "admin": true
}
```

So it seems to me that it is more appropriate to pass a list of names, along with the admin flag. This works nicely in tests, but would cause breaking changes for anyone using the existing `create_users` signature.